### PR TITLE
Tax invoice converter

### DIFF
--- a/app/converters/TaxInvoiceConverter.scala
+++ b/app/converters/TaxInvoiceConverter.scala
@@ -11,16 +11,16 @@ import utilities.Json
 @Singleton
 class TaxInvoiceConverter {
   def convertTradeAgreementToJson(tradeAgreement: TradeAgreement): JsValue = {
-    val buyerAddress = convertAddressToJsonAddress(tradeAgreement.buyer.address)
-    val sellerAddress = convertAddressToJsonAddress(tradeAgreement.seller.address)
-    val buyer = convertBuyerToJsonBuyer(tradeAgreement.buyer, buyerAddress)
-    val seller = convertSellerToJsonSeller(tradeAgreement.seller, sellerAddress)
+    val buyerAddress = convertAddressToJson(tradeAgreement.buyer.address)
+    val sellerAddress = convertAddressToJson(tradeAgreement.seller.address)
+    val buyer = convertBuyerToJson(tradeAgreement.buyer, buyerAddress)
+    val seller = convertSellerToJson(tradeAgreement.seller, sellerAddress)
     val taxInvoice = TaxInvoice(seller, buyer)
 
     Json.toJson(taxInvoice)
   }
 
-  private def convertAddressToJsonAddress(tradeAgreementAddress: CommercialTransaction.Address): Address = {
+  private def convertAddressToJson(tradeAgreementAddress: CommercialTransaction.Address): Address = {
     val address = Address(
       tradeAgreementAddress.buildingName+" "
         +tradeAgreementAddress.buildingNumber,
@@ -38,7 +38,7 @@ class TaxInvoiceConverter {
     address
   }
 
-  private def convertBuyerToJsonBuyer(dealer: Dealer, buyerAddress: Address): Buyer = {
+  private def convertBuyerToJson(dealer: Dealer, buyerAddress: Address): Buyer = {
     val buyer = Buyer(
       dealer.taxPayerId,
       "",
@@ -52,7 +52,7 @@ class TaxInvoiceConverter {
     buyer
   }
 
-  private def convertSellerToJsonSeller(dealer: Dealer, sellerAddress: Address): Seller = {
+  private def convertSellerToJson(dealer: Dealer, sellerAddress: Address): Seller = {
     val seller = Seller(
       dealer.taxPayerId,
       "",

--- a/app/converters/TaxInvoiceConverter.scala
+++ b/app/converters/TaxInvoiceConverter.scala
@@ -1,0 +1,68 @@
+package converters
+
+import javax.inject.Singleton
+
+import converters.messages.Json.{Address, Buyer, Seller, TaxInvoice}
+import models.CommercialTransaction
+import models.TradeAgreement.{Dealer, TradeAgreement}
+import play.api.libs.json.JsValue
+import utilities.Json
+
+@Singleton
+class TaxInvoiceConverter {
+  def convertTradeAgreementToJson(tradeAgreement: TradeAgreement): JsValue = {
+    val buyerAddress = convertAddressToJsonAddress(tradeAgreement.buyer.address)
+    val sellerAddress = convertAddressToJsonAddress(tradeAgreement.seller.address)
+    val buyer = convertBuyerToJsonBuyer(tradeAgreement.buyer, buyerAddress)
+    val seller = convertSellerToJsonSeller(tradeAgreement.seller, sellerAddress)
+    val taxInvoice = TaxInvoice(seller, buyer)
+
+    Json.toJson(taxInvoice)
+  }
+
+  private def convertAddressToJsonAddress(tradeAgreementAddress: CommercialTransaction.Address): Address = {
+    val address = Address(
+      tradeAgreementAddress.buildingName+" "
+        +tradeAgreementAddress.buildingNumber,
+      tradeAgreementAddress.streetName+" "
+        +tradeAgreementAddress.subDistrictCode+" "
+        +tradeAgreementAddress.districtCode+" "
+        +tradeAgreementAddress.countrySubDivisionCode+" "
+        +tradeAgreementAddress.postalCode,
+      tradeAgreementAddress.districtCode,
+      tradeAgreementAddress.subDistrictCode,
+      tradeAgreementAddress.postalCode,
+      tradeAgreementAddress.countrySubDivisionCode,
+      tradeAgreementAddress.countryCode)
+
+    address
+  }
+
+  private def convertBuyerToJsonBuyer(dealer: Dealer, buyerAddress: Address): Buyer = {
+    val buyer = Buyer(
+      dealer.taxPayerId,
+      "",
+      "",
+      dealer.name,
+      dealer.email,
+      "",
+      "",
+      buyerAddress)
+
+    buyer
+  }
+
+  private def convertSellerToJsonSeller(dealer: Dealer, sellerAddress: Address): Seller = {
+    val seller = Seller(
+      dealer.taxPayerId,
+      "",
+      "",
+      dealer.name,
+      dealer.email,
+      "",
+      "",
+      sellerAddress)
+
+    seller
+  }
+}

--- a/app/converters/messages/Json/Address.scala
+++ b/app/converters/messages/Json/Address.scala
@@ -1,4 +1,4 @@
-package converters.models.Json
+package converters.messages.Json
 
 case class Address(
     lineOne: String,

--- a/app/converters/messages/Json/Buyer.scala
+++ b/app/converters/messages/Json/Buyer.scala
@@ -1,4 +1,4 @@
-package converters.models.Json
+package converters.messages.Json
 
 case class Buyer(
     taxNumber: String,

--- a/app/converters/messages/Json/Seller.scala
+++ b/app/converters/messages/Json/Seller.scala
@@ -1,4 +1,4 @@
-package converters.models.Json
+package converters.messages.Json
 
 case class Seller(
     taxNumber: String,

--- a/app/converters/messages/Json/TaxInvoice.scala
+++ b/app/converters/messages/Json/TaxInvoice.scala
@@ -1,3 +1,3 @@
-package converters.models.Json
+package converters.messages.Json
 
 case class TaxInvoice(seller: Seller, buyer: Buyer)

--- a/app/mocks/data/ConverterTestData.scala
+++ b/app/mocks/data/ConverterTestData.scala
@@ -1,0 +1,14 @@
+package mocks.data
+
+import converters.messages.Json.{Address, Buyer, Seller, TaxInvoice}
+
+object ConverterTestData {
+  private val address = Address("building 789", "sukhumvit asjdh district bangkok 123",
+    "district", "asjdh", "123", "bangkok", "thailand")
+  private val seller = Seller("taxPayerId", "", "", "name", "email", "", "", address)
+  private val buyer = Buyer("taxPayerId", "", "", "name", "email", "", "", address)
+  private val taxInvoice = TaxInvoice(seller, buyer)
+
+  def getMockTaxInvoice: TaxInvoice = taxInvoice
+}
+

--- a/test/converters/TaxInvoiceConverterTest.scala
+++ b/test/converters/TaxInvoiceConverterTest.scala
@@ -1,0 +1,15 @@
+package converters
+
+import mocks.data.{ConverterTestData, MockData}
+import org.scalatest.FunSuite
+import utilities.Json
+
+class TaxInvoiceConverterTest extends FunSuite {
+  private val taxInvoiceConverter = new TaxInvoiceConverter
+  private val tradeAgreement = MockData.getMockTradeAgreement
+  private val taxInvoice = Json.toJson(ConverterTestData.getMockTaxInvoice)
+
+  test("TaxInvoiceConverter should return taxInvoice Json") {
+    assert(taxInvoiceConverter.convertTradeAgreementToJson(tradeAgreement) === taxInvoice)
+  }
+}

--- a/test/converters/messages/Json/AddressTest.scala
+++ b/test/converters/messages/Json/AddressTest.scala
@@ -1,4 +1,4 @@
-package converters.models.Json
+package converters.messages.Json
 
 import org.scalatest.FunSuite
 

--- a/test/converters/messages/Json/BuyerTest.scala
+++ b/test/converters/messages/Json/BuyerTest.scala
@@ -1,4 +1,4 @@
-package converters.models.Json
+package converters.messages.Json
 
 import org.scalatest.FunSuite
 

--- a/test/converters/messages/Json/SellerTest.scala
+++ b/test/converters/messages/Json/SellerTest.scala
@@ -1,4 +1,4 @@
-package converters.models.Json
+package converters.messages.Json
 
 import org.scalatest.FunSuite
 

--- a/test/converters/messages/Json/TaxInvoiceTest.scala
+++ b/test/converters/messages/Json/TaxInvoiceTest.scala
@@ -1,4 +1,4 @@
-package converters.models.Json
+package converters.messages.Json
 
 import org.scalatest.FunSuite
 


### PR DESCRIPTION
มีการเเก้ชื่อ models ไปเป็น messages ใน package converters
เเละ ข้อมูลที่ส่งเข้ามาในconverterยังมาไม่ครบจึงทำการให้ข้อมูลที่ไม่มี เป็น ""  